### PR TITLE
Add regression test for missing proxy files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+HSD_CONCURRENCY=10
+HSD_TIMEOUT=12
+HSD_RENDER=false
+HSD_HEADFUL=false
+HSD_RATE_LIMIT_PER_DOMAIN=2.0
+HSD_USER_AGENT=hotel-social-discover/0.1
+HSD_CHECKPOINT_PATH=.hotel_social_discover_checkpoint.json
+HSD_SUMMARY_JSON=results.summary.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,99 @@
-# Codex
+# Hotel Social Discover
+
+Hotel Social Discover is an asyncio friendly crawler that inspects hotel websites to identify social media profiles. It respects robots.txt directives, performs optional JavaScript rendering via Playwright, and outputs normalized social profile links.
+
+## Features
+
+- Async HTTP fetching with retries using `httpx` and `tenacity`.
+- Robots.txt compliance for the `hotel-social-discover` user agent.
+- Heuristic detection of JavaScript-heavy pages with optional Playwright rendering (headless by default).
+- Extraction and normalization of social profile links (Facebook, Instagram, X/Twitter, YouTube, TikTok, LinkedIn, and others).
+- Optional PNG snapshots from Playwright for debugging.
+- Incremental resume capability using a JSON checkpoint file.
+- CSV input/output with detailed metadata and JSON summary export.
+- Structured logging with rotating file handlers.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+playwright install --with-deps chromium
+```
+
+> ⚠️ Playwright browser downloads are large. Skip the install command above if you will only perform static HTTP fetching.
+
+## Configuration
+
+Configuration values are loaded from environment variables and a `.env` file. See the bundled `.env` for defaults.
+
+Key options:
+
+- `HSD_CONCURRENCY`: Maximum concurrent tasks (default 10).
+- `HSD_RATE_LIMIT_PER_DOMAIN`: Minimum seconds between requests to the same domain (default 2.0).
+- `HSD_USER_AGENT`: User agent string for both HTTP requests and robots.txt checks.
+- `HSD_CHECKPOINT_PATH`: Path to resume checkpoint JSON file (default `.hotel_social_discover_checkpoint.json`).
+
+## Usage
+
+```bash
+python cli.py crawl \
+  --input examples/hotels.csv \
+  --output results.csv \
+  --concurrency 10 \
+  --timeout 12 \
+  --headful=false \
+  --proxy-file proxies.txt \
+  --resume=true \
+  --save-snapshots
+```
+
+### Arguments
+
+- `--input`: Path to CSV file containing hotel records. Must include `hotel_id`, `hotel_name`, and `url` columns.
+- `--output`: Path to CSV output file (required).
+- `--concurrency`: Maximum concurrent crawls (overrides default).
+- `--timeout`: Request timeout in seconds (default from config).
+- `--headful`: `true` or `false` to run Playwright in headful mode. Rendering is disabled unless `--render` is also passed.
+- `--render`: Enable Playwright rendering when heuristics indicate dynamic content.
+- `--proxy-file`: Optional path to newline-separated proxy URLs.
+- `--resume`: Enable checkpoint resume (default true). Use `--force` to ignore checkpoint entries.
+- `--save-snapshots`: Save rendered page screenshots alongside CSV output.
+- `--summary-json`: Path to JSON summary file (default `results.summary.json`).
+
+## CSV Input
+
+Input CSV columns must include:
+
+```
+hotel_id,hotel_name,url
+```
+
+Extra columns are preserved during processing.
+
+## Output
+
+The output CSV contains:
+
+```
+hotel_id,hotel_name,url,canonical_url,http_status,response_time_ms,found:facebook,facebook_url,found:instagram,instagram_url,found:x,x_url,found:youtube,youtube_url,found:tiktok,tiktok_url,found:linkedin,linkedin_url,other_socials,page_snapshot_path,last_checked_utc_iso,error_message
+```
+
+## Legal & Ethical Notice
+
+**Use this tool only on websites that you own or are authorized to crawl.** Respect each website's terms of service, robots.txt directives, and rate limits. Never attempt to bypass CAPTCHAs, authentication gates, or other access controls. The authors accept no responsibility for misuse.
+
+## Development
+
+Run tests with:
+
+```bash
+pytest
+```
+
+## Example
+
+```
+python cli.py crawl --input examples/hotels.csv --output results.csv --render --save-snapshots
+```

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,301 @@
+"""Command line interface for Hotel Social Discover."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections import Counter
+from itertools import cycle
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import httpx
+
+from hotel_social_discover.checkpoint import CheckpointStore
+from hotel_social_discover.config import load_config, parse_bool
+from hotel_social_discover.fetcher import Fetcher
+from hotel_social_discover.logging_utils import configure_logging, get_logger
+from hotel_social_discover.parser import parse_social_links
+from hotel_social_discover.robots import RobotsManager
+from hotel_social_discover.storage import ResultRow, read_input_csv, write_output_csv, write_summary_json
+from hotel_social_discover.url_tools import resolve_redirects
+
+logger = get_logger(__name__)
+
+# IMPORTANT: Only crawl websites you are authorized to access. Respect robots.txt and terms of service.
+
+
+SHORTENER_DOMAINS = {
+    "bit.ly",
+    "t.co",
+    "tinyurl.com",
+    "ow.ly",
+    "buff.ly",
+    "rebrand.ly",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Hotel Social Discover CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    crawl = subparsers.add_parser("crawl", help="Crawl hotel websites for social links")
+    crawl.add_argument("--input", required=True, help="Input CSV with hotels")
+    crawl.add_argument("--output", required=True, help="Output CSV for results")
+    crawl.add_argument("--concurrency", type=int, help="Max concurrency")
+    crawl.add_argument("--timeout", type=float, help="Request timeout")
+    crawl.add_argument("--headful", type=str, default=None, help="Run Playwright headful true/false")
+    crawl.add_argument("--render", action="store_true", help="Enable Playwright rendering")
+    crawl.add_argument("--proxy-file", type=str, help="Optional proxy list file")
+    crawl.add_argument("--resume", type=str, default="true", help="Enable resume true/false")
+    crawl.add_argument("--force", action="store_true", help="Process even if checkpoint has entry")
+    crawl.add_argument("--save-snapshots", action="store_true", help="Save rendered page screenshots")
+    crawl.add_argument("--summary-json", type=str, help="Summary JSON output path")
+    crawl.add_argument("--log-file", type=str, help="Optional log file path")
+
+    return parser
+
+
+async def process_hotel(
+    record: Dict[str, str],
+    fetcher: Fetcher,
+    robots: RobotsManager,
+    checkpoint: CheckpointStore,
+    proxy: Optional[str],
+    force: bool,
+    resume_enabled: bool,
+    summary: Counter,
+) -> ResultRow:
+    hotel_id = record.get("hotel_id") or record.get("id") or ""
+    hotel_name = record.get("hotel_name") or record.get("name") or ""
+    url = record.get("url") or record.get("website") or ""
+
+    if not url:
+        return ResultRow(hotel_id=hotel_id, hotel_name=hotel_name, url=url, error_message="missing_url")
+
+    if resume_enabled and checkpoint.is_processed(url) and not force:
+        cached = checkpoint.get(url) or {}
+        summary["skipped_checkpoint"] += 1
+        return ResultRow(
+            hotel_id=hotel_id,
+            hotel_name=hotel_name,
+            url=url,
+            canonical_url=cached.get("canonical_url"),
+            http_status=cached.get("http_status"),
+            response_time_ms=cached.get("response_time_ms"),
+            found_facebook=cached.get("found_facebook", False),
+            facebook_url=cached.get("facebook_url"),
+            found_instagram=cached.get("found_instagram", False),
+            instagram_url=cached.get("instagram_url"),
+            found_x=cached.get("found_x", False),
+            x_url=cached.get("x_url"),
+            found_youtube=cached.get("found_youtube", False),
+            youtube_url=cached.get("youtube_url"),
+            found_tiktok=cached.get("found_tiktok", False),
+            tiktok_url=cached.get("tiktok_url"),
+            found_linkedin=cached.get("found_linkedin", False),
+            linkedin_url=cached.get("linkedin_url"),
+            other_socials=cached.get("other_socials", []),
+            page_snapshot_path=cached.get("page_snapshot_path"),
+            error_message=cached.get("error_message"),
+        )
+
+    allowed = await robots.allowed(url)
+    if not allowed:
+        summary["skipped_robots"] += 1
+        row = ResultRow(hotel_id=hotel_id, hotel_name=hotel_name, url=url, error_message="blocked_by_robots")
+        if resume_enabled:
+            checkpoint.set(url, row.to_dict())
+        return row
+
+    fetch_result = await fetcher.fetch(url, proxy=proxy)
+    if fetch_result.error:
+        summary["errors"] += 1
+        row = ResultRow(
+            hotel_id=hotel_id,
+            hotel_name=hotel_name,
+            url=url,
+            canonical_url=fetch_result.final_url,
+            http_status=fetch_result.status_code,
+            response_time_ms=fetch_result.elapsed_ms,
+            error_message=fetch_result.error,
+        )
+        if resume_enabled:
+            checkpoint.set(url, row.to_dict())
+        return row
+
+    summary["scanned"] += 1
+
+    bucket, others = parse_social_links(fetch_result.body or "", fetch_result.final_url)
+
+    # Resolve shortened URLs
+    resolved_cache: Dict[str, str] = {}
+    async def resolve(link: str) -> str:
+        if link in resolved_cache:
+            return resolved_cache[link]
+        domain = httpx.URL(link).host or ""
+        if domain in SHORTENER_DOMAINS:
+            resolved_cache[link] = await resolve_redirects(fetcher.client, link)
+        else:
+            resolved_cache[link] = link
+        return resolved_cache[link]
+
+    facebook_urls = [await resolve(url) for url in bucket["facebook"]]
+    instagram_urls = [await resolve(url) for url in bucket["instagram"]]
+    x_urls = [await resolve(url) for url in bucket["x"]]
+    youtube_urls = [await resolve(url) for url in bucket["youtube"]]
+    tiktok_urls = [await resolve(url) for url in bucket["tiktok"]]
+    linkedin_urls = [await resolve(url) for url in bucket["linkedin"]]
+
+    for platform, items in (
+        ("facebook", facebook_urls),
+        ("instagram", instagram_urls),
+        ("x", x_urls),
+        ("youtube", youtube_urls),
+        ("tiktok", tiktok_urls),
+        ("linkedin", linkedin_urls),
+    ):
+        if items:
+            summary[f"found_{platform}"] += len(items)
+
+    row = ResultRow(
+        hotel_id=hotel_id,
+        hotel_name=hotel_name,
+        url=url,
+        canonical_url=fetch_result.final_url,
+        http_status=fetch_result.status_code,
+        response_time_ms=fetch_result.elapsed_ms,
+        found_facebook=bool(facebook_urls),
+        facebook_url="|".join(facebook_urls) if facebook_urls else None,
+        found_instagram=bool(instagram_urls),
+        instagram_url="|".join(instagram_urls) if instagram_urls else None,
+        found_x=bool(x_urls),
+        x_url="|".join(x_urls) if x_urls else None,
+        found_youtube=bool(youtube_urls),
+        youtube_url="|".join(youtube_urls) if youtube_urls else None,
+        found_tiktok=bool(tiktok_urls),
+        tiktok_url="|".join(tiktok_urls) if tiktok_urls else None,
+        found_linkedin=bool(linkedin_urls),
+        linkedin_url="|".join(linkedin_urls) if linkedin_urls else None,
+        other_socials=others,
+        page_snapshot_path=fetch_result.snapshot_path,
+    )
+
+    if resume_enabled:
+        checkpoint.set(url, row.to_dict())
+    return row
+
+
+async def crawl_command(args: argparse.Namespace) -> None:
+    config = load_config()
+
+    if args.concurrency:
+        config.concurrency = args.concurrency
+    if args.timeout:
+        config.timeout = args.timeout
+    if args.headful is not None:
+        config.headful = parse_bool(args.headful)
+    if args.render:
+        config.render = True
+    proxy_values: Optional[List[str]] = None
+    missing_proxy_path: Optional[Path] = None
+    if args.proxy_file:
+        proxy_path = Path(args.proxy_file)
+        if proxy_path.exists():
+            proxy_values = [line.strip() for line in proxy_path.read_text().splitlines() if line.strip()]
+        else:
+            missing_proxy_path = proxy_path
+    if args.summary_json:
+        config.summary_json = Path(args.summary_json)
+
+    resume_enabled = parse_bool(args.resume)
+
+    configure_logging(Path(args.log_file) if args.log_file else None)
+
+    if proxy_values is not None:
+        config.proxy_list = proxy_values
+    elif missing_proxy_path is not None:
+        logger.warning("Proxy file %s not found; continuing without proxies", missing_proxy_path)
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    records = read_input_csv(input_path)
+    logger.info("Loaded %s records from %s", len(records), input_path)
+
+    proxy_cycle = cycle(config.proxy_list) if config.proxy_list else None
+
+    async with httpx.AsyncClient(
+        headers={"User-Agent": config.user_agent},
+        follow_redirects=True,
+    ) as client:
+        robots = RobotsManager(config.user_agent, client)
+        fetcher = Fetcher(
+            client=client,
+            timeout=config.timeout,
+            render=config.render,
+            headful=config.headful,
+            rate_limit_per_domain=config.rate_limit_per_domain,
+            user_agent=config.user_agent,
+            save_snapshots=args.save_snapshots,
+            snapshot_dir=str(output_path.parent / "snapshots") if args.save_snapshots else None,
+        )
+
+        checkpoint = CheckpointStore(config.checkpoint_path)
+
+        semaphore = asyncio.Semaphore(config.concurrency)
+        summary: Counter = Counter()
+        results: List[ResultRow] = []
+
+        async def worker(record: Dict[str, str]) -> None:
+            async with semaphore:
+                proxy = next(proxy_cycle) if proxy_cycle else None
+                row = await process_hotel(
+                    record=record,
+                    fetcher=fetcher,
+                    robots=robots,
+                    checkpoint=checkpoint,
+                    proxy=proxy,
+                    force=args.force,
+                    resume_enabled=resume_enabled,
+                    summary=summary,
+                )
+                results.append(row)
+
+        await asyncio.gather(*(worker(record) for record in records))
+
+        if resume_enabled:
+            checkpoint.save()
+
+    write_output_csv(output_path, results)
+    logger.info("Wrote %s rows to %s", len(results), output_path)
+
+    summary_dict = {
+        "scanned": summary.get("scanned", 0),
+        "skipped_checkpoint": summary.get("skipped_checkpoint", 0),
+        "skipped_robots": summary.get("skipped_robots", 0),
+        "errors": summary.get("errors", 0),
+        "found_facebook": summary.get("found_facebook", 0),
+        "found_instagram": summary.get("found_instagram", 0),
+        "found_x": summary.get("found_x", 0),
+        "found_youtube": summary.get("found_youtube", 0),
+        "found_tiktok": summary.get("found_tiktok", 0),
+        "found_linkedin": summary.get("found_linkedin", 0),
+    }
+
+    write_summary_json(config.summary_json, summary_dict)
+    logger.info("Summary saved to %s", config.summary_json)
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "crawl":
+        asyncio.run(crawl_command(args))
+    else:
+        parser.error("Unknown command")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hotels.csv
+++ b/examples/hotels.csv
@@ -1,0 +1,3 @@
+hotel_id,hotel_name,url
+1,Sample Hotel,https://example.com
+2,Resort Paradise,https://example.org

--- a/fixtures/sample_page.html
+++ b/fixtures/sample_page.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hotel Example</title>
+</head>
+<body>
+    <a href="https://www.facebook.com/samplehotel">Facebook</a>
+    <a href="https://instagram.com/samplehotel">Instagram</a>
+    <a href="https://twitter.com/samplehotel">Twitter</a>
+    <a href="https://www.youtube.com/channel/abc">YouTube</a>
+    <a href="https://www.linkedin.com/company/samplehotel">LinkedIn</a>
+    <a href="https://tiktok.com/@samplehotel">TikTok</a>
+    <a href="https://www.pinterest.com/samplehotel">Pinterest</a>
+</body>
+</html>

--- a/hotel_social_discover/__init__.py
+++ b/hotel_social_discover/__init__.py
@@ -1,0 +1,13 @@
+"""Hotel Social Discover package."""
+
+__all__ = [
+    "config",
+    "logging_utils",
+    "robots",
+    "fetcher",
+    "parser",
+    "storage",
+    "checkpoint",
+]
+
+__version__ = "0.1.0"

--- a/hotel_social_discover/checkpoint.py
+++ b/hotel_social_discover/checkpoint.py
@@ -1,0 +1,35 @@
+"""Checkpoint management for incremental resume."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+
+class CheckpointStore:
+    """Simple JSON-based checkpoint store."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._data: Dict[str, Dict] = {}
+        if self.path.exists():
+            try:
+                self._data = json.loads(self.path.read_text())
+            except Exception:
+                self._data = {}
+
+    def is_processed(self, key: str) -> bool:
+        return key in self._data
+
+    def get(self, key: str) -> Optional[Dict]:
+        return self._data.get(key)
+
+    def set(self, key: str, value: Dict) -> None:
+        self._data[key] = value
+
+    def save(self) -> None:
+        self.path.write_text(json.dumps(self._data, indent=2, sort_keys=True))
+
+
+__all__ = ["CheckpointStore"]

--- a/hotel_social_discover/config.py
+++ b/hotel_social_discover/config.py
@@ -1,0 +1,61 @@
+"""Configuration utilities for Hotel Social Discover."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from dotenv import load_dotenv
+
+
+@dataclass
+class Config:
+    """Runtime configuration parameters."""
+
+    concurrency: int = 10
+    timeout: float = 12.0
+    render: bool = False
+    headful: bool = False
+    rate_limit_per_domain: float = 2.0
+    user_agent: str = "hotel-social-discover/0.1"
+    checkpoint_path: Path = Path(".hotel_social_discover_checkpoint.json")
+    summary_json: Path = Path("results.summary.json")
+    proxy_list: Optional[List[str]] = None
+
+
+def parse_bool(value: str) -> bool:
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def load_config(env_file: Optional[str] = ".env") -> Config:
+    """Load configuration from environment variables and optional .env file."""
+
+    if env_file:
+        load_dotenv(env_file, override=False)
+
+    config = Config(
+        concurrency=int(os.getenv("HSD_CONCURRENCY", Config.concurrency)),
+        timeout=float(os.getenv("HSD_TIMEOUT", Config.timeout)),
+        render=parse_bool(os.getenv("HSD_RENDER", str(Config.render)).lower()),
+        headful=parse_bool(os.getenv("HSD_HEADFUL", str(Config.headful)).lower()),
+        rate_limit_per_domain=float(
+            os.getenv("HSD_RATE_LIMIT_PER_DOMAIN", Config.rate_limit_per_domain)
+        ),
+        user_agent=os.getenv("HSD_USER_AGENT", Config.user_agent),
+        checkpoint_path=Path(
+            os.getenv("HSD_CHECKPOINT_PATH", str(Config.checkpoint_path))
+        ),
+        summary_json=Path(os.getenv("HSD_SUMMARY_JSON", str(Config.summary_json))),
+    )
+
+    proxy_file = os.getenv("HSD_PROXY_FILE")
+    if proxy_file and Path(proxy_file).exists():
+        proxies = Path(proxy_file).read_text().splitlines()
+        config.proxy_list = [p.strip() for p in proxies if p.strip()]
+
+    return config
+
+
+__all__ = ["Config", "load_config", "parse_bool"]

--- a/hotel_social_discover/fetcher.py
+++ b/hotel_social_discover/fetcher.py
@@ -1,0 +1,143 @@
+"""Async fetching utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+import httpx
+from tenacity import AsyncRetrying, RetryError, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from .parser import is_js_heavy, looks_like_captcha
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional heavy dependency
+    from playwright.async_api import async_playwright
+except Exception:  # pragma: no cover
+    async_playwright = None  # type: ignore
+
+
+@dataclass
+class FetchResult:
+    url: str
+    final_url: str
+    status_code: Optional[int]
+    body: Optional[str]
+    elapsed_ms: Optional[int]
+    error: Optional[str] = None
+    snapshot_path: Optional[str] = None
+
+
+class Fetcher:
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        timeout: float,
+        render: bool,
+        headful: bool,
+        rate_limit_per_domain: float,
+        user_agent: str,
+        save_snapshots: bool = False,
+        snapshot_dir: Optional[str] = None,
+    ) -> None:
+        self.client = client
+        self.timeout = timeout
+        self.render = render and async_playwright is not None
+        self.headful = headful
+        self.rate_limit_per_domain = rate_limit_per_domain
+        self.user_agent = user_agent
+        self.save_snapshots = save_snapshots
+        self.snapshot_dir = snapshot_dir
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._last_request: dict[str, float] = {}
+
+    async def _rate_limit(self, url: str) -> None:
+        parsed = urlparse(url)
+        host = parsed.netloc
+        lock = self._locks.setdefault(host, asyncio.Lock())
+        async with lock:
+            now = time.monotonic()
+            last = self._last_request.get(host, 0.0)
+            delta = now - last
+            if delta < self.rate_limit_per_domain:
+                await asyncio.sleep(self.rate_limit_per_domain - delta)
+            self._last_request[host] = time.monotonic()
+
+    async def fetch(self, url: str, render_hint: bool = False, proxy: Optional[str] = None) -> FetchResult:
+        await self._rate_limit(url)
+        start = time.perf_counter()
+        try:
+            async for attempt in AsyncRetrying(
+                reraise=True,
+                stop=stop_after_attempt(3),
+                wait=wait_exponential(multiplier=1, min=1, max=4),
+                retry=retry_if_exception_type((httpx.HTTPError, httpx.TimeoutException)),
+            ):
+                with attempt:
+                    response = await self.client.get(
+                        url,
+                        timeout=self.timeout,
+                        proxies=proxy if proxy else None,
+                    )
+                    elapsed_ms = int((time.perf_counter() - start) * 1000)
+                    body = response.text
+                    if looks_like_captcha(body):
+                        return FetchResult(
+                            url=url,
+                            final_url=str(response.url),
+                            status_code=response.status_code,
+                            body=body,
+                            elapsed_ms=elapsed_ms,
+                            error="captcha_detected",
+                        )
+                    need_render = self.render and (render_hint or is_js_heavy(body))
+                    snapshot_path = None
+                    if need_render:
+                        rendered = await self.render_page(str(response.url))
+                        if rendered:
+                            body, snapshot_path = rendered
+                    return FetchResult(
+                        url=url,
+                        final_url=str(response.url),
+                        status_code=response.status_code,
+                        body=body,
+                        elapsed_ms=elapsed_ms,
+                        snapshot_path=snapshot_path,
+                    )
+        except RetryError as exc:
+            last_attempt = exc.last_attempt
+            error_message = str(last_attempt.exception()) if last_attempt else str(exc)
+            return FetchResult(url=url, final_url=url, status_code=None, body=None, elapsed_ms=None, error=error_message)
+        except Exception as exc:
+            return FetchResult(url=url, final_url=url, status_code=None, body=None, elapsed_ms=None, error=str(exc))
+
+    async def render_page(self, url: str) -> Optional[tuple[str, Optional[str]]]:
+        if async_playwright is None:
+            logger.debug("Playwright not installed; skipping render")
+            return None
+        try:
+            async with async_playwright() as p:  # pragma: no cover - heavy
+                browser = await p.chromium.launch(headless=not self.headful)
+                page = await browser.new_page(user_agent=self.user_agent)
+                await page.goto(url, wait_until="networkidle", timeout=self.timeout * 1000)
+                content = await page.content()
+                snapshot_path = None
+                if self.save_snapshots and self.snapshot_dir:
+                    Path = __import__("pathlib").Path  # lazy import
+                    Path(self.snapshot_dir).mkdir(parents=True, exist_ok=True)
+                    safe_name = urlparse(url).netloc.replace(":", "_")
+                    snapshot_path = str(Path(self.snapshot_dir) / f"{safe_name}.png")
+                    await page.screenshot(path=snapshot_path, full_page=True)
+                await browser.close()
+                return content, snapshot_path
+        except Exception as exc:  # pragma: no cover - heavy
+            logger.debug("Playwright rendering failed for %s: %s", url, exc)
+            return None
+
+
+__all__ = ["Fetcher", "FetchResult"]

--- a/hotel_social_discover/logging_utils.py
+++ b/hotel_social_discover/logging_utils.py
@@ -1,0 +1,42 @@
+"""Structured logging helpers."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+
+def configure_logging(log_file: Optional[Path] = None, level: int = logging.INFO) -> None:
+    """Configure console and optional file logging."""
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+
+    # Avoid duplicate handlers
+    if root_logger.handlers:
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    root_logger.addHandler(console_handler)
+
+    if log_file:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(log_file, maxBytes=5_000_000, backupCount=3)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/hotel_social_discover/parser.py
+++ b/hotel_social_discover/parser.py
@@ -1,0 +1,164 @@
+"""HTML parsing and social link normalization."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+from urllib.parse import parse_qs, urlencode, urljoin, urlparse, urlunparse
+
+try:
+    from bs4 import BeautifulSoup
+except Exception:  # pragma: no cover - fallback when dependency missing
+    BeautifulSoup = None  # type: ignore
+    from html.parser import HTMLParser
+
+    class _AnchorCollector(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.anchors: List[str] = []
+
+        def handle_starttag(self, tag: str, attrs):  # type: ignore[override]
+            if tag.lower() != "a":
+                return
+            for key, value in attrs:
+                if key.lower() == "href" and value:
+                    self.anchors.append(value)
+
+    def _fallback_parse_anchors(html: str) -> List[str]:
+        parser = _AnchorCollector()
+        parser.feed(html)
+        return parser.anchors
+else:
+    def _fallback_parse_anchors(html: str) -> List[str]:  # pragma: no cover - bs4 path
+        soup = BeautifulSoup(html, "lxml")
+        return [a.get("href") or "" for a in soup.find_all("a", href=True)]
+
+try:
+    import tldextract
+except Exception:  # pragma: no cover - fallback when dependency missing
+    tldextract = None  # type: ignore
+
+    def _extract_domain(netloc: str) -> str:
+        return netloc.lower()
+else:
+    def _extract_domain(netloc: str) -> str:  # pragma: no cover - full dependency path
+        ext = tldextract.extract(netloc)
+        netloc_parts = [part for part in [ext.subdomain, ext.registered_domain] if part]
+        return ".".join(netloc_parts).lower() if netloc_parts else netloc.lower()
+
+SOCIAL_PATTERNS = {
+    "facebook": re.compile(r"facebook\.com", re.I),
+    "instagram": re.compile(r"instagram\.com", re.I),
+    "x": re.compile(r"(?:twitter|x)\.com", re.I),
+    "youtube": re.compile(r"(?:youtube\.com|youtu\.be)", re.I),
+    "tiktok": re.compile(r"tiktok\.com", re.I),
+    "linkedin": re.compile(r"linkedin\.com", re.I),
+}
+
+TRACKING_PARAMS = {
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "fbclid",
+    "gclid",
+}
+
+
+@dataclass
+class SocialLink:
+    platform: Optional[str]
+    url: str
+
+
+def normalize_url(url: str, base_url: Optional[str] = None) -> Optional[str]:
+    if not url:
+        return None
+
+    url = unicodedata.normalize("NFKC", url.strip())
+    if url.startswith("//"):
+        url = "https:" + url
+    if base_url:
+        url = urljoin(base_url, url)
+
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        parsed = parsed._replace(scheme="https")
+    if not parsed.netloc:
+        return None
+
+    parsed = parsed._replace(netloc=_extract_domain(parsed.netloc))
+
+    query = parse_qs(parsed.query, keep_blank_values=False)
+    cleaned_query = {k: v for k, v in query.items() if k.lower() not in TRACKING_PARAMS}
+    parsed = parsed._replace(query=urlencode(cleaned_query, doseq=True))
+
+    # remove fragments
+    parsed = parsed._replace(fragment="")
+
+    normalized = urlunparse(parsed)
+    return normalized
+
+
+def detect_platform(url: str) -> Optional[str]:
+    for platform, pattern in SOCIAL_PATTERNS.items():
+        if pattern.search(url):
+            return platform
+    return None
+
+
+def resolve_duplicates(links: Iterable[SocialLink]) -> Tuple[Dict[str, List[str]], List[str]]:
+    bucket: Dict[str, List[str]] = {platform: [] for platform in SOCIAL_PATTERNS}
+    others: List[str] = []
+    for link in links:
+        if link.platform and link.platform in bucket:
+            if link.url not in bucket[link.platform]:
+                bucket[link.platform].append(link.url)
+        else:
+            if link.url not in others:
+                others.append(link.url)
+    return bucket, others
+
+
+def parse_social_links(html: str, base_url: str) -> Tuple[Dict[str, List[str]], List[str]]:
+    anchors = _fallback_parse_anchors(html)
+    links: List[SocialLink] = []
+    for raw_href in anchors:
+        href = normalize_url(raw_href, base_url)
+        if not href:
+            continue
+        platform = detect_platform(href)
+        links.append(SocialLink(platform=platform, url=href))
+
+    return resolve_duplicates(links)
+
+
+def is_js_heavy(html: str) -> bool:
+    if not html:
+        return True
+    scripts = html.lower().count("<script")
+    anchors = html.lower().count("<a")
+    if len(html) < 2_000:
+        return True
+    if scripts > 20 and anchors < 5:
+        return True
+    return False
+
+
+def looks_like_captcha(html: str) -> bool:
+    if not html:
+        return False
+    return bool(re.search(r"captcha", html, re.I))
+
+
+__all__ = [
+    "parse_social_links",
+    "normalize_url",
+    "detect_platform",
+    "resolve_duplicates",
+    "is_js_heavy",
+    "looks_like_captcha",
+]

--- a/hotel_social_discover/robots.py
+++ b/hotel_social_discover/robots.py
@@ -1,0 +1,81 @@
+"""Robots.txt fetching and compliance."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+try:  # pragma: no cover - optional dependency
+    from robotexclusionrulesparser import RobotExclusionRulesParser as RobotsParser
+except Exception:  # pragma: no cover
+    from urllib import robotparser as _robotparser
+
+    class RobotsParser:  # type: ignore
+        def __init__(self) -> None:
+            self._parser = _robotparser.RobotFileParser()
+
+        def set_url(self, url: str) -> None:
+            self._parser.set_url(url)
+
+        def read(self) -> None:
+            self._parser.read()
+
+        def can_fetch(self, useragent: str, url: str) -> bool:
+            return self._parser.can_fetch(useragent, url)
+
+        def parse(self, content: str) -> None:
+            self._parser.parse(content.splitlines())
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RobotsCacheEntry:
+    parser: RobotsParser
+    fetched: bool
+
+
+class RobotsManager:
+    """Manage robots.txt fetching and caching."""
+
+    def __init__(self, user_agent: str, client: httpx.AsyncClient) -> None:
+        self.user_agent = user_agent
+        self.client = client
+        self._lock = asyncio.Lock()
+        self._cache: Dict[str, RobotsCacheEntry] = {}
+
+    async def allowed(self, url: str) -> bool:
+        parsed = urlparse(url)
+        base = f"{parsed.scheme}://{parsed.netloc}"
+        async with self._lock:
+            entry = self._cache.get(base)
+            if entry is None:
+                entry = RobotsCacheEntry(parser=RobotsParser(), fetched=False)
+                self._cache[base] = entry
+
+        if not entry.fetched:
+            robots_url = urljoin(base, "/robots.txt")
+            try:
+                response = await self.client.get(robots_url, timeout=10.0)
+                response.raise_for_status()
+                entry.parser.parse(response.text)
+                logger.debug("Fetched robots.txt from %s", robots_url)
+            except Exception as exc:  # pragma: no cover - network dependent
+                logger.debug("Failed to fetch robots.txt from %s: %s", robots_url, exc)
+            finally:
+                entry.fetched = True
+
+        try:
+            allowed = entry.parser.can_fetch(self.user_agent, url)
+        except Exception:
+            allowed = True
+        return allowed if allowed is not None else True
+
+
+__all__ = ["RobotsManager"]

--- a/hotel_social_discover/storage.py
+++ b/hotel_social_discover/storage.py
@@ -1,0 +1,116 @@
+"""CSV and summary storage utilities."""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+OUTPUT_COLUMNS = [
+    "hotel_id",
+    "hotel_name",
+    "url",
+    "canonical_url",
+    "http_status",
+    "response_time_ms",
+    "found:facebook",
+    "facebook_url",
+    "found:instagram",
+    "instagram_url",
+    "found:x",
+    "x_url",
+    "found:youtube",
+    "youtube_url",
+    "found:tiktok",
+    "tiktok_url",
+    "found:linkedin",
+    "linkedin_url",
+    "other_socials",
+    "page_snapshot_path",
+    "last_checked_utc_iso",
+    "error_message",
+]
+
+
+@dataclass
+class ResultRow:
+    hotel_id: str
+    hotel_name: str
+    url: str
+    canonical_url: Optional[str] = None
+    http_status: Optional[int] = None
+    response_time_ms: Optional[int] = None
+    found_facebook: bool = False
+    facebook_url: Optional[str] = None
+    found_instagram: bool = False
+    instagram_url: Optional[str] = None
+    found_x: bool = False
+    x_url: Optional[str] = None
+    found_youtube: bool = False
+    youtube_url: Optional[str] = None
+    found_tiktok: bool = False
+    tiktok_url: Optional[str] = None
+    found_linkedin: bool = False
+    linkedin_url: Optional[str] = None
+    other_socials: List[str] = field(default_factory=list)
+    page_snapshot_path: Optional[str] = None
+    last_checked_utc_iso: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    error_message: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        return {
+            "hotel_id": self.hotel_id,
+            "hotel_name": self.hotel_name,
+            "url": self.url,
+            "canonical_url": self.canonical_url or "",
+            "http_status": self.http_status if self.http_status is not None else "",
+            "response_time_ms": self.response_time_ms if self.response_time_ms is not None else "",
+            "found:facebook": str(self.found_facebook).lower(),
+            "facebook_url": self.facebook_url or "",
+            "found:instagram": str(self.found_instagram).lower(),
+            "instagram_url": self.instagram_url or "",
+            "found:x": str(self.found_x).lower(),
+            "x_url": self.x_url or "",
+            "found:youtube": str(self.found_youtube).lower(),
+            "youtube_url": self.youtube_url or "",
+            "found:tiktok": str(self.found_tiktok).lower(),
+            "tiktok_url": self.tiktok_url or "",
+            "found:linkedin": str(self.found_linkedin).lower(),
+            "linkedin_url": self.linkedin_url or "",
+            "other_socials": "|".join(self.other_socials),
+            "page_snapshot_path": self.page_snapshot_path or "",
+            "last_checked_utc_iso": self.last_checked_utc_iso,
+            "error_message": self.error_message or "",
+        }
+
+
+def read_input_csv(path: Path) -> List[Dict[str, str]]:
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return [dict(row) for row in reader]
+
+
+def write_output_csv(path: Path, rows: Iterable[ResultRow]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=OUTPUT_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row.to_dict())
+
+
+def write_summary_json(path: Path, summary: Dict[str, int]) -> None:
+    path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+
+
+__all__ = [
+    "ResultRow",
+    "read_input_csv",
+    "write_output_csv",
+    "write_summary_json",
+    "OUTPUT_COLUMNS",
+]

--- a/hotel_social_discover/url_tools.py
+++ b/hotel_social_discover/url_tools.py
@@ -1,0 +1,31 @@
+"""URL helper utilities."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+
+
+async def resolve_redirects(client: httpx.AsyncClient, url: str, max_hops: int = 5) -> str:
+    current = url
+    for _ in range(max_hops):
+        try:
+            response = await client.head(current, follow_redirects=False, timeout=10.0)
+        except Exception:
+            return current
+        if response.status_code in {301, 302, 303, 307, 308} and "location" in response.headers:
+            current = response.headers["location"]
+            if not current.startswith("http"):
+                # Fallback to GET with follow redirects to resolve relative
+                try:
+                    final = await client.get(url, follow_redirects=True, timeout=10.0)
+                    return str(final.url)
+                except Exception:
+                    return url
+        else:
+            return current
+    return current
+
+
+__all__ = ["resolve_redirects"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hotel-social-discover"
+version = "0.1.0"
+description = "Async crawler to discover hotel social media profiles"
+readme = "README.md"
+authors = [{name = "Hotel Social Discover"}]
+license = {text = "MIT"}
+requires-python = ">=3.9"
+dependencies = [
+    "httpx[http2]",
+    "playwright>=1.40",
+    "beautifulsoup4",
+    "lxml",
+    "aiofiles",
+    "tenacity",
+    "python-dotenv",
+    "pandas",
+    "tldextract",
+    "robotexclusionrulesparser; python_version<'3.11'",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-asyncio"]
+
+[tool.setuptools]
+packages = ["hotel_social_discover"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+import argparse
+
+import asyncio
+
+import cli
+
+
+def test_crawl_handles_missing_proxy_file(tmp_path, monkeypatch, caplog):
+    input_path = tmp_path / "hotels.csv"
+    input_path.write_text("hotel_id,hotel_name,url\n")
+    output_path = tmp_path / "results.csv"
+    summary_path = tmp_path / "summary.json"
+    checkpoint_path = tmp_path / "checkpoint.json"
+
+    monkeypatch.setenv("HSD_CHECKPOINT_PATH", str(checkpoint_path))
+    monkeypatch.setenv("HSD_SUMMARY_JSON", str(summary_path))
+
+    args = argparse.Namespace(
+        command="crawl",
+        input=str(input_path),
+        output=str(output_path),
+        concurrency=None,
+        timeout=None,
+        headful=None,
+        render=False,
+        proxy_file=str(tmp_path / "proxies.txt"),
+        resume="true",
+        force=False,
+        save_snapshots=False,
+        summary_json=str(summary_path),
+        log_file=None,
+    )
+
+    monkeypatch.setattr(cli, "configure_logging", lambda *_, **__: None)
+
+    caplog.set_level("WARNING")
+
+    asyncio.run(cli.crawl_command(args))
+
+    assert output_path.exists(), "Output CSV should be created even when proxies are missing"
+    assert summary_path.exists(), "Summary JSON should be written"
+    assert checkpoint_path.exists(), "Checkpoint file should be saved"
+    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert any("Proxy file" in record.message for record in warnings), "Missing proxy file warning not logged"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,25 @@
+import pathlib
+
+from hotel_social_discover import parser
+
+
+def test_normalize_url_removes_tracking():
+    url = "https://facebook.com/page?utm_source=test&ref=home#section"
+    normalized = parser.normalize_url(url)
+    assert normalized == "https://facebook.com/page?ref=home"
+
+
+def test_parse_social_links_detects_platforms():
+    html = pathlib.Path("fixtures/sample_page.html").read_text()
+    bucket, others = parser.parse_social_links(html, "https://example.com")
+    assert bucket["facebook"] == ["https://www.facebook.com/samplehotel"]
+    assert bucket["instagram"] == ["https://instagram.com/samplehotel"]
+    assert bucket["x"] == ["https://twitter.com/samplehotel"]
+    assert bucket["youtube"] == ["https://www.youtube.com/channel/abc"]
+    assert bucket["linkedin"] == ["https://www.linkedin.com/company/samplehotel"]
+    assert bucket["tiktok"] == ["https://tiktok.com/@samplehotel"]
+    assert "https://www.pinterest.com/samplehotel" in others
+
+
+def test_is_js_heavy_handles_short_content():
+    assert parser.is_js_heavy("<html></html>")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from hotel_social_discover.storage import ResultRow, read_input_csv, write_output_csv
+
+
+def test_read_input_csv(tmp_path: Path):
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text("hotel_id,hotel_name,url\n1,Test Hotel,https://example.com\n")
+    rows = read_input_csv(csv_path)
+    assert rows == [{"hotel_id": "1", "hotel_name": "Test Hotel", "url": "https://example.com"}]
+
+
+def test_write_output_csv(tmp_path: Path):
+    output_path = tmp_path / "out.csv"
+    row = ResultRow(hotel_id="1", hotel_name="Test Hotel", url="https://example.com")
+    write_output_csv(output_path, [row])
+    content = output_path.read_text().splitlines()
+    assert content[0].startswith("hotel_id,hotel_name")
+    assert "1" in content[1]


### PR DESCRIPTION
## Summary
- add a regression test that exercises the crawl CLI when the proxy file is missing
- ensure the crawl still produces output artifacts and emits a warning instead of crashing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6b1ffad888323881248ede20a4078